### PR TITLE
Update app.js: Use arrow functions in quit() promise

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -217,9 +217,9 @@ class App {
    */
   quit() {
     if (!this.app || !this.app.isRunning()) return Promise.resolve();
-    return this.app.stop().then(function() {
+    return this.app.stop().then(() => {
       assert.equal(this.app.isRunning(), false);
-    }).catch(function(err) {
+    }).catch((err) => {
       debug('Quitting Compass failed due to error: ', err);
     });
   }


### PR DESCRIPTION
i.e. `this.app` with this change should resolve as appears to have been intended inside the `.then` callback.

Avoids the following downstream TypeError:

```
pzrq@rocket:~/Projects/compass$ DEBUG=* npm test -- --functional -g '#launch|#collections'
...
Tue, 08 Aug 2017 05:17:11 GMT hadron-spectron:app Quitting Compass failed due to error:  TypeError: Cannot read property 'app' of undefined
    at /Users/pzrq/Projects/compass/node_modules/hadron-spectron/lib/app.js:221:24
    at process._tickDomainCallback (internal/process/next_tick.js:129:7)
```