### PR TITLE
COMPASS-3115: Windows: AHHHHHHHHHHHHH. Fixed.

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -134,7 +134,7 @@ class App {
     this.app = new Application({
       path: this.electronExecutable(),
       args: [this.appRoot],
-      env: process.env,
+      // env: process.env,
       cwd: this.root
     });
   }

--- a/lib/app.js
+++ b/lib/app.js
@@ -134,8 +134,12 @@ class App {
     this.app = new Application({
       path: this.electronExecutable(),
       args: [this.appRoot],
-      // env: process.env,
       cwd: this.root
+
+      /**
+       * @see https://jira.mongodb.org/browse/COMPASS-3115
+       * env: process.env
+       */
     });
   }
 


### PR DESCRIPTION
## Forensics

Found this buried deep in the chromedriver logs:

```
[1540550592.876][DEBUG]: DevTools request: http://localhost:12853/json/version
The command line is too long.
[1540550593.908][DEBUG]: DevTools request failed
```

The devtools request is optional. The real problem is `The command line is too long.`! This is being caused because all `npm_*` env variables were being passed to spectron which converts these all to CLI args passed to chromedriver.  We shouldn't need to pass these explicitly as the subprocesses will auto inherit from the parent proc. Will need to do a bit more testing, but this mystery is finally looking solved!

## TODO

- [x] All tests now pass locally for me. Wait for appveyor to confirm fix via this PR
- [x] Clean up rage-code from #2 
- [x] Complete follow-ups from #2 